### PR TITLE
Add orchestrator and grading tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ env_logger = "0.11.8"
 log = "0.4.27"
 rayon = "1.10.0"
 osqp = "1.0.1"
+
+[workspace]
+members = ["orchestrator", "sim_agent", "grade_push"]

--- a/grade_push/Cargo.toml
+++ b/grade_push/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "grade_push"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
+serde_json = "1"

--- a/grade_push/src/main.rs
+++ b/grade_push/src/main.rs
@@ -1,0 +1,23 @@
+use clap::Parser;
+use std::fs;
+
+#[derive(Parser)]
+struct Args {
+    /// Path to results.json
+    path: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let data = fs::read_to_string(&args.path)?;
+    println!("Pushing grade results from {}", args.path);
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://lrs.example.com/statement")
+        .body(data)
+        .send()
+        .await?;
+    println!("LRS response: {}", resp.status());
+    Ok(())
+}

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "orchestrator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4"
+bollard = { version = "0.15", features = ["ssl"] }
+rand = "0.8"
+rsa = "0.9"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -1,0 +1,120 @@
+use actix_web::{web, App, HttpServer, Responder};
+use serde::{Deserialize, Serialize};
+use anyhow::Result;
+use bollard::{Docker, container::{Config, CreateContainerOptions, StartContainerOptions}, models::{HostConfig, PortBinding, ContainerCreateResponse}};
+use rand::{distributions::Alphanumeric, Rng};
+use rsa::{pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding}, RsaPrivateKey};
+use std::{collections::HashMap, time::Duration};
+
+#[derive(Serialize)]
+struct SshLaunch {
+    host: String,
+    port: u16,
+    user: String,
+    private_key_pem: String,
+}
+
+#[derive(Deserialize)]
+struct LaunchReq {
+    learner: String,
+}
+
+async fn launch_handler(q: web::Query<LaunchReq>) -> actix_web::Result<impl Responder> {
+    let info = launch_ssh_pod(&q.learner).await.map_err(actix_web::error::ErrorInternalServerError)?;
+    Ok(web::Json(info))
+}
+
+async fn launch_ssh_pod(learner_id: &str) -> Result<SshLaunch> {
+    let key = RsaPrivateKey::new(&mut rand::thread_rng(), 2048)?;
+    let priv_pem = key.to_pkcs8_pem(LineEnding::LF)?.to_string();
+    let pub_ssh = key
+        .to_public_key()
+        .to_public_key_pem(LineEnding::LF)?
+        .replace("-----BEGIN PUBLIC KEY-----\n", "")
+        .replace("-----END PUBLIC KEY-----", "");
+
+    let cname: String = format!(
+        "sim-{}-{}",
+        learner_id,
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(6)
+            .map(char::from)
+            .collect::<String>()
+    );
+
+    let docker = Docker::connect_with_socket_defaults()?;
+    let create_cfg = Config {
+        image: Some("robot-sim:latest".into()),
+        env: Some(vec![format!("SSH_PUBKEY={}", pub_ssh)]),
+        exposed_ports: Some(
+            [("2222/tcp".into(), HashMap::<(), ()>::new())]
+                .iter()
+                .cloned()
+                .collect(),
+        ),
+        host_config: Some(HostConfig {
+            port_bindings: Some(
+                [(
+                    "2222/tcp".into(),
+                    Some(vec![PortBinding {
+                        host_ip: Some("0.0.0.0".into()),
+                        host_port: Some("0".into()),
+                    }]),
+                )]
+                .iter()
+                .cloned()
+                .collect(),
+            ),
+            memory: Some(512 * 1024 * 1024),
+            pids_limit: Some(512),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let ContainerCreateResponse { id, .. } = docker
+        .create_container(Some(CreateContainerOptions { name: cname, platform: None }), create_cfg)
+        .await?;
+    docker
+        .start_container(&id, None::<StartContainerOptions<String>>)
+        .await?;
+
+    let inspect = docker.inspect_container(&id, None).await?;
+    let port_map = inspect
+        .network_settings
+        .and_then(|n| n.ports)
+        .ok_or_else(|| anyhow::anyhow!("missing port map"))?;
+    let binding = port_map
+        .get("2222/tcp")
+        .and_then(|v| v.as_ref())
+        .and_then(|v| v.first())
+        .ok_or_else(|| anyhow::anyhow!("missing port binding"))?;
+    let port = binding
+        .host_port
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("missing host port"))?
+        .parse::<u16>()?;
+
+    let docker_cleanup = docker.clone();
+    let id_cleanup = id.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(5400)).await;
+        let _ = docker_cleanup.stop_container(&id_cleanup, None).await;
+        let _ = docker_cleanup.remove_container(&id_cleanup, None).await;
+    });
+
+    Ok(SshLaunch {
+        host: "lab.example.com".into(),
+        port,
+        user: "student".into(),
+        private_key_pem: priv_pem,
+    })
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| App::new().route("/launch", web::get().to(launch_handler)))
+        .bind(("0.0.0.0", 8080))?
+        .run()
+        .await
+}

--- a/sim_agent/Cargo.toml
+++ b/sim_agent/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sim_agent"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+notify = "6"
+anyhow = "1"

--- a/sim_agent/src/main.rs
+++ b/sim_agent/src/main.rs
@@ -1,0 +1,23 @@
+use notify::{RecommendedWatcher, RecursiveMode, Watcher, Event};
+use std::{process::Command, sync::mpsc::channel, path::Path};
+
+fn main() -> anyhow::Result<()> {
+    let (tx, rx) = channel();
+    let mut watcher = RecommendedWatcher::new(tx, notify::Config::default())?;
+    watcher.watch(Path::new("/workspace"), RecursiveMode::NonRecursive)?;
+
+    for event in rx {
+        if let Ok(ev) = event {
+            handle_event(ev);
+        }
+    }
+    Ok(())
+}
+
+fn handle_event(event: Event) {
+    if event.paths.iter().any(|p| p.ends_with("results.json")) {
+        let _ = Command::new("/usr/local/bin/grade_push")
+            .arg(&event.paths[0])
+            .status();
+    }
+}


### PR DESCRIPTION
## Summary
- convert repository to a cargo workspace and add orchestrator, sim_agent, and grade_push crates
- orchestrator provides an Actix-Web service to create SSH pods via Docker
- sim_agent watches for `results.json` and launches grade_push
- grade_push posts results to a placeholder LRS endpoint

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68868363e044832492a45262f7ed8fb5